### PR TITLE
✅ test: add model shape coverage

### DIFF
--- a/tests/test_model_shapes.py
+++ b/tests/test_model_shapes.py
@@ -1,0 +1,45 @@
+from __future__ import annotations
+
+import pytest
+import torch
+
+from eeg_networks import EEGInception, EEGSpatialLSTM
+
+
+@pytest.mark.parametrize(
+    ("model", "input_tensor", "expected_shape"),
+    [
+        pytest.param(
+            EEGInception(num_classes=2),
+            torch.zeros(4, 1, 128, 8),
+            (4, 2),
+            id="eeg-inception",
+        ),
+        pytest.param(
+            EEGSpatialLSTM(num_classes=2, input_size=16, hidden_size=16),
+            torch.zeros(4, 1, 128, 8),
+            (4, 2),
+            id="eeg-spatial-lstm-shared",
+        ),
+        pytest.param(
+            EEGSpatialLSTM(
+                num_classes=2,
+                input_size=16,
+                hidden_size=16,
+                dependent=True,
+            ),
+            torch.zeros(4, 1, 128, 8),
+            (4, 2),
+            id="eeg-spatial-lstm-dependent",
+        ),
+    ],
+)
+def test_model_output_shapes(
+    model: torch.nn.Module, input_tensor: torch.Tensor, expected_shape: tuple[int, int]
+) -> None:
+    model.eval()
+
+    with torch.no_grad():
+        output = model(input_tensor)
+
+    assert output.shape == expected_shape


### PR DESCRIPTION
## 摘要
- 新增 `tests/test_model_shapes.py`，为仓库当前公开的模型补充基础形状测试
- 使用 `pytest` 对 `EEGInception`、共享 LSTM 版本的 `EEGSpatialLSTM` 以及 `dependent=True` 的 `EEGSpatialLSTM` 进行前向推理校验
- 采用 `torch.zeros(4, 1, 128, 8)` 作为示例输入，并断言输出张量形状为 `(4, 2)`

## 验证
- `./.venv/bin/python -m pytest tests/test_model_shapes.py`
- `uvx ruff check tests/test_model_shapes.py`
- `uvx ruff format --check tests/test_model_shapes.py`